### PR TITLE
fix: 服务端 generation_cache 被持续清空 & lz4 空 jar 构建

### DIFF
--- a/gradle/lz4-relocate.gradle
+++ b/gradle/lz4-relocate.gradle
@@ -10,7 +10,11 @@ ext.configureLz4Shadow = { task ->
 }
 
 ext.configureLz4ShadowExcludes = { task ->
-    task.exclude 'net/jpountz/**'
+    // 注意：不要在这里 exclude 'net/jpountz/**'。
+    // shadow 的 exclude 先于 relocate 执行，会在重定位前把原始类全部排除，
+    // 导致 lz4-relocated 产出一个空 jar（Issue #13 评论）。
+    // relocate（configureLz4Shadow）已将包名改为 com.mapsyncer.net.jpountz，
+    // loader 模块经 bundle 拿到的也是重定位后的包名，不会残留裸 net/jpountz。
     task.exclude 'org/slf4j/**'
     task.exclude 'META-INF/versions/9/module-info.class'
     task.exclude 'META-INF/*.SF'

--- a/libs/common/src/main/java/com/mapsyncer/server/GenerationCache.java
+++ b/libs/common/src/main/java/com/mapsyncer/server/GenerationCache.java
@@ -250,24 +250,42 @@ public class GenerationCache {
         if (!Files.isDirectory(dimDir)) {
             return null;
         }
+        String fileName = parts[parts.length - 1] + ".zip";
+
+        // 服务端缓存目录是扁平的：zip 直接位于维度目录下，无 mw$ 中间层。
+        //   地表：{dimDir}/{region}.zip
+        //   洞穴：{dimDir}/caves/{layer}/{region}.zip
+        Path flatPath;
+        if (parts.length == 2) {
+            flatPath = dimDir.resolve(fileName);
+        } else if (parts.length == 4 && "caves".equals(parts[1])) {
+            flatPath = dimDir.resolve("caves").resolve(parts[2]).resolve(fileName);
+        } else {
+            flatPath = null;
+        }
+        if (flatPath != null && Files.isRegularFile(flatPath)) {
+            return flatPath;
+        }
+
+        // 回退：mw$ 是客户端 Xaero Worldmap 的目录约定（{dimDir}/mw$id/{region}.zip）。
+        // 用于兼容含 mw$ 子目录的布局。
         Path mwDir;
         try (var stream = Files.list(dimDir)) {
             mwDir = stream.filter(p -> p.getFileName().toString().startsWith("mw$"))
                     .findFirst().orElse(null);
         } catch (IOException e) {
-            return null;
+            return flatPath;
         }
         if (mwDir == null) {
-            return null;
+            return flatPath;
         }
-        String fileName = parts[parts.length - 1] + ".zip";
         if (parts.length == 2) {
             return mwDir.resolve(fileName);
         }
         if (parts.length == 4 && "caves".equals(parts[1])) {
             return mwDir.resolve("caves").resolve(parts[2]).resolve(fileName);
         }
-        return null;
+        return flatPath;
     }
 
     /**


### PR DESCRIPTION
本 PR 修复 v1.0.4 的两个构建/运行时问题，已在实服验证通过。

## 1. 服务端 generation_cache 被持续清空导致全量重传、玩家掉线（#14）

### 根因

`GenerationCache.resolveZipPath()` 假设维度目录下存在 `mw$` 子目录（客户端 Xaero Worldmap 的目录约定），但**服务端缓存目录是扁平结构**——`XaeroWriter.writeRegionFile()` 直接将 zip 写到 `{dimDir}/{regionX}_{regionZ}.zip`，无 `mw$` 中间层：

```
server_map_cache/
├── null/
│   ├── -1_0.zip      ← 直接在维度目录下
│   └── caves/3/0_0.zip
└── DIM-1/
    └── caves/3/0_0.zip
```

因此 `resolveZipPath` 对所有地表 region（`parts.length == 2`）返回 `null` → `pruneInvalidEntries` 将刚由 `ConversionOrchestrator` 写入的有效条目误判为"无效"删除。

死循环链路：

```
ConversionOrchestrator 转换 region → genCache.update() ✅ 写入
玩家同步 → pruneInvalidEntries() → resolveZipPath() 找不到 mw$ → null → 误删 ❌
→ serverCache.get(path) == null → 现场算 hash，timestamp = 当前时间
→ 客户端旧 timestamp < 服务端当前时间 → 判定需传输 → 全量重传
→ 网络队列压垮 → keepalive 超时 → 玩家掉线
```

### 修复

`resolveZipPath` 优先按服务端扁平结构解析（`dim/region.zip`、`dim/caves/layer/region.zip`），文件存在即返回；不存在时回退 `mw$` 查找，兼容客户端布局。

### 实服验证

| 指标 | 修复前 | 修复后 |
|------|--------|--------|
| `Pruned` 误删日志 | 每次同步 10~16 条 | **0 条** |
| `hash match` | 永远 0 | **29**（第二次同步起）|
| 同步传输量 | 每次全量 88~93 regions | 收敛到真实增量 **5 regions** |
| keepalive 超时掉线 | 频繁 | 消失 |

Close #14

---

## 2. lz4-relocated 空 jar 构建（#13 评论）

`configureLz4ShadowExcludes` 中的 `task.exclude 'net/jpountz/**'` 在 shadow 执行时**先于 relocate 匹配**，把待重定位的原始 lz4 类全部排除，导致 `lz4-relocated` 产出一个仅含 MANIFEST 的空 jar（293 字节），下游 core 编译报：

```
McaReader.java:12: 错误: 程序包com.mapsyncer.net.jpountz.lz4不存在
```

`relocate`（`configureLz4Shadow`）已将包名改为 `com.mapsyncer.net.jpountz`，不会残留裸 `net/jpountz`，该 exclude 多余且有害。移除后 `lz4-relocated` jar 从 293 字节变为 129KB，含 84 个重定位类，裸 `net/jpountz` 为 0。

> #13 的主体重定位方案（独立 `lz4-relocated` 模块）作者已在 `df14915` 修复，本 PR 仅处理评论中反馈的这条多余 exclude。

---

## 检查清单

- [x] 实服部署验证（NeoForge 1.21.1）
- [x] 构建验证（`mapsyncer-1.0.4-neoforge-1.21.jar` 正常产出，lz4 重定位类 84 个）
- [x] 回退兼容（客户端 `mw$` 布局保留回退分支）