### PR TITLE
feat: add FULL cave layer, fix Nether cave rendering and dead config defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ logs/
 
 # Claude Code
 .claude/
+.serena/
 
 # 参考资料（反编译源码、工具 JAR、日志等，不参与构建）
 .reference/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 | **带宽控制** | 可配置单包大小与 KB/s 限速；大包自动分片组装 |
 | **断点续传** | 基于客户端哈希缓存，中断后可恢复 |
 | **视距优先** | 视距内区域优先传输；视距外可限速喂给 Xaero |
-| **维度 / 洞穴** | 原版与 Mod 维度；`dimension = layerPlan`（SURFACE / ALL / 显式 Y / 组合） |
+| **维度 / 洞穴** | 原版与 Mod 维度；`dimension = layerPlan`（SURFACE / ALL / FULL / 显式 Y / 组合） |
 | **增量更新** | 服务端 DISABLED / TICK / SCHEDULED 自动更新地图缓存 |
 | **自动同步** | 按服务端模式进服或在线自动拉取（可关）；手动 sync 始终可用 |
 | **并发转换** | `maxConcurrentRegions`：0=自动（逻辑核−2，上限 16） |
@@ -143,7 +143,7 @@ NeoForge / Fabric 配置文件位于 `config/` 目录下（NeoForge 为 `.toml`�
 ```toml
 dimension_configs = [
     "minecraft:overworld = SURFACE",
-    "minecraft:the_nether = SURFACE,63",
+    "minecraft:the_nether = SURFACE,ALL,FULL",
     "minecraft:the_end = SURFACE"
 ]
 ```
@@ -153,15 +153,16 @@ dimension_configs = [
 | 值 | 说明 |
 |----|------|
 | `SURFACE` | 仅地表。无顶盖为全列扫描；有顶盖（地狱）为逻辑顶以上（Y≥128） |
-| `ALL` | 维度高度范围内全部洞穴层 |
+| `ALL` | 维度可玩高度范围内全部洞穴层 |
+| `FULL` | Xaero “完整”洞穴模式的独立全深度层 |
 | `63` / `63,127` | 仅指定洞穴层（caveStart Y），不含地表 |
-| `SURFACE,63` / `SURFACE,ALL` / `ALL,63` | 组合；`ALL` 与显式 Y 按层号去重 |
+| `SURFACE,63` / `SURFACE,ALL,FULL` / `ALL,63` | 组合；`ALL` 与显式 Y 按层号去重 |
 
 - 仅写 `SURFACE` **不会**自动生成洞穴；需洞穴须写 Y 或 `ALL`
-- 地狱默认 `SURFACE,63`：逻辑顶以上地表 + 洞穴 Y=63（Xaero 层号 3 → `caves/3/`）
+- 地狱默认 `SURFACE,ALL,FULL`：关闭、分层和完整三种 Xaero 洞穴模式均有对应数据
 - 兼容：`维度|layerPlan`、旧多字段管道、Fabric 旧键；维度类型信息运行时从 API 获取，不写进配置
 
-**洞穴层号**：`caveStart >> 4`（Y=63 → 层 3 → `caves/3/`）。
+**洞穴层号**：`caveStart >> 4`（Y=63 → 层 3 → `caves/3/`）；`FULL` 写入 Xaero 的 `caves/-2147483648/` 独立层。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -44,7 +44,7 @@ Supports dedicated and integrated servers (LAN). On integrated servers, the host
 | **Bandwidth control** | Configurable packet size & KB/s limit; auto fragment large payloads |
 | **Resumable sync** | Client hash cache; resume after disconnect |
 | **View-distance priority** | In-view first; out-of-view drain rate configurable |
-| **Dimensions / caves** | Vanilla + mod dims; `dimension = layerPlan` (SURFACE / ALL / Y / combos) |
+| **Dimensions / caves** | Vanilla + mod dims; `dimension = layerPlan` (SURFACE / ALL / FULL / Y / combos) |
 | **Incremental update** | Server DISABLED / TICK / SCHEDULED cache refresh |
 | **Auto sync** | Join / online pull by server mode (toggleable); manual sync always works |
 | **Concurrent conversion** | `maxConcurrentRegions`: **0 = auto** (`logical CPUs − 2`, capped at 16) |
@@ -134,7 +134,7 @@ NeoForge: `config/mapsyncer-server.toml` · Fabric: `config/mapsyncer-server.pro
 ```toml
 dimension_configs = [
     "minecraft:overworld = SURFACE",
-    "minecraft:the_nether = SURFACE,63",
+    "minecraft:the_nether = SURFACE,ALL,FULL",
     "minecraft:the_end = SURFACE"
 ]
 ```
@@ -142,9 +142,12 @@ dimension_configs = [
 | layerPlan | Description |
 |-----------|-------------|
 | `SURFACE` | Surface only; ceiling dims scan above logical top (Nether Y≥128) |
-| `ALL` | All cave layers in height range |
+| `ALL` | All cave layers in the playable height range |
+| `FULL` | Separate full-depth layer used by Xaero's Full cave mode |
 | `63` / `63,127` | Explicit cave layers only |
-| `SURFACE,63` / … | Combinations; layer index = `caveStart >> 4` → `caves/<n>/` |
+| `SURFACE,ALL,FULL` / … | Combinations; explicit layer index = `caveStart >> 4` → `caves/<n>/` |
+
+The Nether defaults to `SURFACE,ALL,FULL`, covering Xaero cave modes Off, Layered, and Full. `FULL` is stored in Xaero's separate `caves/-2147483648/` layer.
 
 Compatible: `dimension|layerPlan`, legacy multi-field pipes, Fabric legacy keys. Dimension type info comes from the server API at runtime (not stored in config).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -125,7 +125,7 @@ mc-{精确版本}/{fabric|forge|neoforge}/   Loader 胶水（Platform 实现、�
 ```toml
 dimension_configs = [
     "minecraft:overworld = SURFACE",
-    "minecraft:the_nether = SURFACE,63",
+    "minecraft:the_nether = SURFACE,ALL,FULL",
     "minecraft:the_end = SURFACE"
 ]
 ```
@@ -133,9 +133,10 @@ dimension_configs = [
 | layerPlan | 说明 |
 |-----------|------|
 | `SURFACE` | 仅地表；有顶盖维度扫逻辑顶以上（如地狱 Y≥128） |
-| `ALL` | 全高度洞穴层 |
+| `ALL` | 可玩高度范围内全部洞穴层 |
+| `FULL` | Xaero “完整”洞穴模式使用的独立全深度层（`caves/-2147483648/`） |
 | `63` / `63,127` | 显式洞穴层（不含地表） |
-| `SURFACE,63` 等 | 组合；层号 = `caveStart >> 4` → `caves/<层号>/` |
+| `SURFACE,ALL,FULL` 等 | 组合；显式层号 = `caveStart >> 4` → `caves/<层号>/` |
 
 **兼容**：`dimension|layerPlan`、旧多字段管道、Fabric 旧键 `dimensionConfig.N` / `dimensionConfigs=a;b`。维度类型信息运行时从服务器 API 获取，**不再写入配置**。
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,9 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=true
 
-# Enable Gradle toolchain auto-download (may fail due to network)
+# Let Gradle discover or provision the toolchain required by each target.
+org.gradle.java.installations.auto-detect=true
 org.gradle.java.installations.auto-download=true
-
-# Java 25 path - for MC 26.1 (main JDK)
-org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jdk-25.0.3.9-hotspot
-
-# Java 17 path - for Forge 1.20.x toolchain
-org.gradle.java.installations.paths=C:/Program Files/Eclipse Adoptium/jdk-17.0.19.10-hotspot,C:/Program Files/Eclipse Adoptium/jdk-21.0.11.10-hotspot,C:/Program Files/Eclipse Adoptium/jdk-25.0.3.9-hotspot
 
 # Mod properties
 mod_id=mapsyncer

--- a/libs/common/src/main/java/com/mapsyncer/config/DimensionConfigParser.java
+++ b/libs/common/src/main/java/com/mapsyncer/config/DimensionConfigParser.java
@@ -12,12 +12,12 @@ import java.util.Properties;
 /**
  * 维度配置解析工具类。
  *
- * <p>推荐条目格式：{@code dimension = layerPlan}（如 {@code minecraft:the_nether = SURFACE,63}）</p>
+ * <p>推荐条目格式：{@code dimension = layerPlan}（如 {@code minecraft:the_nether = SURFACE,ALL,FULL}）</p>
  * <p>Fabric 与 Forge/NeoForge 均使用列表风格：</p>
  * <pre>
  * dimension_configs = [
  *     "minecraft:overworld = SURFACE",
- *     "minecraft:the_nether = SURFACE,63"
+ *     "minecraft:the_nether = SURFACE,ALL,FULL"
  * ]
  * </pre>
  * <p>兼容：{@code dimension|layerPlan}、旧多字段管道格式、Fabric 旧
@@ -60,9 +60,13 @@ public final class DimensionConfigParser {
     public static List<String> getDefaultDimensionConfigStrings() {
         List<String> defaults = new ArrayList<>(3);
         defaults.add(formatEntry("minecraft:overworld", LayerPlan.surfaceOnly()));
-        defaults.add(formatEntry("minecraft:the_nether", LayerPlan.mixed(DEFAULT_CAVE_START)));
+        defaults.add(formatEntry("minecraft:the_nether", defaultNetherPlan()));
         defaults.add(formatEntry("minecraft:the_end", LayerPlan.surfaceOnly()));
         return defaults;
+    }
+
+    private static LayerPlan defaultNetherPlan() {
+        return new LayerPlan(true, true, List.of(LayerPlan.FULL_CAVE_START));
     }
 
     public static void invalidateCache() {
@@ -182,7 +186,7 @@ public final class DimensionConfigParser {
      * <pre>
      * dimension_configs = [
      *     "minecraft:overworld = SURFACE",
-     *     "minecraft:the_nether = SURFACE,63"
+     *     "minecraft:the_nether = SURFACE,ALL,FULL"
      * ]
      * </pre>
      * <p>否则回退 {@link #loadEntriesFromProperties}（旧 {@code dimensionConfig.N} / 分号拼接）。</p>
@@ -404,14 +408,14 @@ public final class DimensionConfigParser {
     public static void appendEntriesToPropertiesFile(StringBuilder sb, List<String> dimensionConfigs) {
         sb.append("# 维度扫描配置（与 Forge/NeoForge 列表风格一致）\n");
         sb.append("# 格式：\"dimension = layerPlan\"\n");
-        sb.append("# layerPlan：SURFACE、ALL、显式 Y（如 63）或组合（如 SURFACE,63）\n");
-        sb.append("# 示例：\"minecraft:the_nether = SURFACE,63\"\n");
+        sb.append("# layerPlan：SURFACE、ALL、FULL、显式 Y（如 63）或组合\n");
+        sb.append("# 示例：\"minecraft:the_nether = SURFACE,ALL,FULL\"\n");
         sb.append("# 旧管道 / dimensionConfig.N / 分号拼接 仍可读取\n");
         sb.append("#\n");
         sb.append("# Per-dimension scan configuration (same list style as Forge/NeoForge)\n");
         sb.append("# Format: \"dimension = layerPlan\"\n");
-        sb.append("# layerPlan: SURFACE, ALL, explicit Y (e.g. 63), or combos (e.g. SURFACE,63)\n");
-        sb.append("# Example: \"minecraft:the_nether = SURFACE,63\"\n");
+        sb.append("# layerPlan: SURFACE, ALL, FULL, explicit Y (e.g. 63), or combinations\n");
+        sb.append("# Example: \"minecraft:the_nether = SURFACE,ALL,FULL\"\n");
         sb.append("# Legacy pipe / dimensionConfig.N / dimensionConfigs=a;b still load\n");
         sb.append(LIST_KEY).append(" = [\n");
         if (dimensionConfigs != null) {
@@ -449,7 +453,7 @@ public final class DimensionConfigParser {
             switch (normalizedPath) {
                 case "the_nether":
                     return new DimensionScanConfig("minecraft:the_nether",
-                        LayerPlan.mixed(DEFAULT_CAVE_START), DimensionTypeInfo.nether());
+                        defaultNetherPlan(), DimensionTypeInfo.nether());
                 case "overworld":
                     return new DimensionScanConfig("minecraft:overworld",
                         LayerPlan.surfaceOnly(), DimensionTypeInfo.overworld());

--- a/libs/common/src/main/java/com/mapsyncer/server/DimensionRegistry.java
+++ b/libs/common/src/main/java/com/mapsyncer/server/DimensionRegistry.java
@@ -7,6 +7,7 @@ import com.mapsyncer.platform.PlatformManager;
 import com.mapsyncer.util.DimensionApiHelper;
 import com.mapsyncer.util.DimensionPathMapping;
 import com.mapsyncer.util.DimensionTypeHelper;
+import com.mapsyncer.util.ModLogConfig;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -43,6 +44,10 @@ public class DimensionRegistry {
      * @param server MinecraftServer实例
      */
     public static void registerAllDimensions(MinecraftServer server) {
+        // 每个 Loader 启动时都会走到这里；在此应用 enableDebugLogging，
+        // 否则该配置只有在 /mapsyncer reloadconfig 之后才会生效。
+        ModLogConfig.applyDebugLogging();
+
         // 防止重复注册
         if (hasRegistered) {
             LOGGER.debug("Dimensions already registered, skipping");
@@ -108,10 +113,13 @@ public class DimensionRegistry {
                 dimTypeInfo = DimensionTypeInfo.fromDimensionId(dimId);
             }
 
-            // 使用默认地表模式和动态维度类型信息创建配置
+            // 层计划取自 default_scan_mode / default_cave_start（原版维度仍用内置默认），
+            // 维度类型信息从运行中的 ServerLevel 动态获取。
+            LayerPlan defaultPlan = PlatformManager.getPlatform()
+                    .getConfigForDimension(dimId).layerPlan();
             DimensionScanConfig finalConfig = new DimensionScanConfig(
                     dimId,
-                    LayerPlan.surfaceOnly(),
+                    defaultPlan,
                     dimTypeInfo
             );
 
@@ -137,7 +145,9 @@ public class DimensionRegistry {
      */
     public static void resetRegistration() {
         hasRegistered = false;
-        DimensionPathMapping.resetInstance();
+        // Keep the Minecraft version selected during mod startup; recreating the
+        // singleton here silently reverted 26.x servers to the 1.21 path layout.
+        DimensionPathMapping.getInstance().clearDetectedMappings();
         LOGGER.info("Dimension registration state reset");
     }
 

--- a/libs/core/src/main/java/com/mapsyncer/mca/ChunkDataParser.java
+++ b/libs/core/src/main/java/com/mapsyncer/mca/ChunkDataParser.java
@@ -264,19 +264,20 @@ public class ChunkDataParser {
      * @param worldHeightRange 维度高度范围
      * @return 每个高度值的位数b
      */
-    private static int calculateBitsPerHeight(int longArrayLength, int worldHeightRange) {
-        // 优先使用维度高度范围计算（更准确）
-        if (worldHeightRange > 0) {
-            // b = ceil(log2(h))
-            return 32 - Integer.numberOfLeadingZeros(worldHeightRange - 1);
+    static int calculateBitsPerHeight(int longArrayLength, int worldHeightRange) {
+        // 与 Xaero/Minecraft 的 packed heightmap 对齐：由实际 LongArray 长度确定位宽。
+        // 256 高维度仍需表示偏移 256，所以是 9 bits，而不是 ceil(log2(256)) = 8。
+        if (longArrayLength > 0) {
+            int storedBits = longArrayLength / 4;
+            if (storedBits > 0) {
+                return storedBits;
+            }
         }
 
-        // 备用：从数组长度反推
-        // l = ceil(256/u) => u ≈ ceil(256/l)
-        // b = floor(64/u)
-        if (longArrayLength <= 0) return 0;
-        int u = (256 + longArrayLength - 1) / longArrayLength; // ceil(256/l)
-        return 64 / u;
+        // 无数组时的保守回退；高度偏移范围包含上界。
+        return worldHeightRange > 0
+            ? 32 - Integer.numberOfLeadingZeros(worldHeightRange)
+            : 0;
     }
 
     /**

--- a/libs/core/src/main/java/com/mapsyncer/mca/ChunkSectionParser.java
+++ b/libs/core/src/main/java/com/mapsyncer/mca/ChunkSectionParser.java
@@ -394,17 +394,21 @@ public class ChunkSectionParser {
      * @param data 位数组数据
      * @return 每个条目的位数
      */
-    private static int calculateBitsPerEntry(int paletteSize, long[] data) {
+    static int calculateBitsPerEntry(int paletteSize, long[] data) {
         if (paletteSize <= 1) {
             return 0;  // 单方块section，无需data数组
         }
 
-        // Wiki规范：c ≤ 16 时 b = 4，否则 b = ceil(log2(c))
-        if (paletteSize <= 16) {
-            return 4;
+        int minimumBits = Math.max(4, 32 - Integer.numberOfLeadingZeros(paletteSize - 1));
+        if (data == null || data.length == 0) {
+            return minimumBits;
         }
-        // ceil(log2(c)) = 32 - numberOfLeadingZeros(c - 1)
-        return 32 - Integer.numberOfLeadingZeros(paletteSize - 1);
+
+        // Modern paletted containers may retain a wider bit width than the current palette needs.
+        // Xaero derives that width from the packed array; using palette size alone shifts entries
+        // into stripes and can turn valid blocks into air when the palette has shrunk.
+        int storedBits = data.length * Long.SIZE / 4096;
+        return Math.max(minimumBits, storedBits);
     }
 
     /**

--- a/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/ChunkColumnScanner.java
+++ b/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/ChunkColumnScanner.java
@@ -85,7 +85,11 @@ public final class ChunkColumnScanner {
 
                     int scanBottomY;
                     int startY;
-                    if (isCaveMode) {
+                    if (fullCave) {
+                        startY = bounds.resolveSurfaceStartY(
+                            ChunkDataParser.getHeightmapStartY(chunk, lx, lz, worldTopY));
+                        scanBottomY = bounds.clampBottomY(minBuildHeight, minBuildHeight);
+                    } else if (isCaveMode) {
                         startY = bounds.clampStartY(caveStart);
                         scanBottomY = bounds.clampBottomY(minBuildHeight,
                             Math.max(caveStart - caveDepth, minBuildHeight));

--- a/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/ColumnScanContext.java
+++ b/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/ColumnScanContext.java
@@ -27,7 +27,6 @@ public final class ColumnScanContext {
     /** 进入空气区域（Xaero: 遇 air 设 underair=true） */
     void onAir(int pos) {
         underair[pos] = true;
-        shouldEnterGround[pos] = false;
     }
 
     /**
@@ -39,9 +38,40 @@ public final class ColumnScanContext {
         }
     }
 
-    /** 洞穴模式：只有 underair 后才可记录实体方块/overlay */
-    boolean canProcessCaveBlock(int pos, boolean isCaveMode) {
-        return !isCaveMode || underair[pos];
+    /**
+     * 对齐 Xaero 的完整洞穴状态机：先穿过最上方地表，再等到空气后记录洞穴表面。
+     */
+    boolean canProcessCaveBlock(int pos, boolean isCaveMode,
+                                ChunkSectionParser.BlockState state,
+                                BlockPropertyLookup lookup) {
+        if (!isCaveMode) {
+            return true;
+        }
+
+        int flags = lookup.getFlags(state.name());
+        boolean fluid = state.isFluid()
+            || (flags & BlockPropertyLookup.FLAG_TRANSLUCENT_FLUID) != 0;
+        if (fluid) {
+            if (shouldEnterGround[pos]) {
+                return false;
+            }
+            underair[pos] = true;
+        }
+
+        if (!underair[pos]) {
+            return false;
+        }
+        if (shouldEnterGround[pos]) {
+            boolean solidGround = (flags & (BlockPropertyLookup.FLAG_INVISIBLE
+                | BlockPropertyLookup.FLAG_SHOULD_OVERLAY)) == 0
+                && (flags & BlockPropertyLookup.FLAG_HAS_VANILLA_COLOR) != 0;
+            if (solidGround) {
+                underair[pos] = false;
+                shouldEnterGround[pos] = false;
+            }
+            return false;
+        }
+        return true;
     }
 
     static boolean hasFluid(ChunkSectionParser.BlockState state, BlockPropertyLookup lookup) {

--- a/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/PixelColumnProcessor.java
+++ b/libs/core/src/main/java/com/mapsyncer/mca/convert/scan/PixelColumnProcessor.java
@@ -58,7 +58,7 @@ public final class PixelColumnProcessor {
             if (isCaveMode && ColumnScanContext.hasFluid(singleState, blockLookup)) {
                 ctx.onFluid(pos, true);
             }
-            if (!ctx.canProcessCaveBlock(pos, isCaveMode)) {
+            if (!ctx.canProcessCaveBlock(pos, isCaveMode, singleState, blockLookup)) {
                 return false;
             }
         }
@@ -98,7 +98,7 @@ public final class PixelColumnProcessor {
                 ctx.onFluid(pos, true);
             }
 
-            if (!ctx.canProcessCaveBlock(pos, isCaveMode)) {
+            if (!ctx.canProcessCaveBlock(pos, isCaveMode, state, blockLookup)) {
                 continue;
             }
 

--- a/libs/platform-api/build.gradle
+++ b/libs/platform-api/build.gradle
@@ -30,3 +30,18 @@ dependencies {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
+
+tasks.register('netherLayerPlanCheck', JavaExec) {
+    dependsOn testClasses
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'com.mapsyncer.config.NetherLayerPlanCheck'
+    enableAssertions = true
+}
+
+tasks.named('test').configure {
+    failOnNoDiscoveredTests = false
+}
+
+tasks.named('check').configure {
+    dependsOn netherLayerPlanCheck
+}

--- a/libs/platform-api/src/main/java/com/mapsyncer/config/DimensionScanConfig.java
+++ b/libs/platform-api/src/main/java/com/mapsyncer/config/DimensionScanConfig.java
@@ -53,7 +53,7 @@ public record DimensionScanConfig(
         }
         int start = caveStart();
         if (start == Integer.MIN_VALUE) {
-            return Math.max(30, start - minBuildHeight);
+            return 30;
         }
         return 15;
     }

--- a/libs/platform-api/src/main/java/com/mapsyncer/config/LayerPlan.java
+++ b/libs/platform-api/src/main/java/com/mapsyncer/config/LayerPlan.java
@@ -10,9 +10,10 @@ import java.util.List;
  * <p>逗号分隔，可组合：</p>
  * <ul>
  *   <li>{@code SURFACE} — 仅地表（有顶盖维度为逻辑顶以上；无顶盖维度为全列）</li>
- *   <li>{@code ALL} — 生成维度高度范围内的全部洞穴层</li>
+ *   <li>{@code ALL} — 生成维度可玩高度范围内的全部洞穴层</li>
+ *   <li>{@code FULL} — 生成 Xaero 完整洞穴模式使用的独立层</li>
  *   <li>{@code 63} / {@code 63,127} — 仅显式洞穴层，不含地表</li>
- *   <li>{@code SURFACE,ALL} / {@code SURFACE,63} / {@code ALL,63} — 组合；与显式 Y 自动去重</li>
+ *   <li>{@code SURFACE,ALL,FULL} / {@code SURFACE,63} — 组合；与显式 Y 自动去重</li>
  *   <li>空 — 由 {@link RegionGenerationPlanner} 回退为仅地表</li>
  * </ul>
  */
@@ -22,6 +23,7 @@ public record LayerPlan(
     List<Integer> caveStarts
 ) {
     public static final int DEFAULT_CAVE_START = 63;
+    public static final int FULL_CAVE_START = Integer.MIN_VALUE;
 
     public LayerPlan {
         caveStarts = caveStarts == null || caveStarts.isEmpty()
@@ -74,7 +76,7 @@ public record LayerPlan(
         if (includeAllCaves) {
             parts.add("ALL");
         }
-        caveStarts.forEach(y -> parts.add(String.valueOf(y)));
+        caveStarts.forEach(y -> parts.add(y == FULL_CAVE_START ? "FULL" : String.valueOf(y)));
         return String.join(",", parts);
     }
 
@@ -92,6 +94,9 @@ public record LayerPlan(
         }
         if (trimmed.equalsIgnoreCase("ALL")) {
             return allCaves();
+        }
+        if (trimmed.equalsIgnoreCase("FULL")) {
+            return caves(FULL_CAVE_START);
         }
 
         if (!trimmed.contains(",")) {
@@ -114,6 +119,8 @@ public record LayerPlan(
                 surface = true;
             } else if (token.equalsIgnoreCase("ALL")) {
                 allCaves = true;
+            } else if (token.equalsIgnoreCase("FULL")) {
+                starts.add(FULL_CAVE_START);
             } else {
                 try {
                     starts.add(Integer.parseInt(token));
@@ -133,6 +140,16 @@ public record LayerPlan(
      * 兼容旧配置 {@code scanMode|caveField} 合并为层计划。
      */
     public static LayerPlan fromLegacy(ScanMode scanMode, String caveField) {
+        String trimmed = caveField == null ? "" : caveField.trim();
+        if (trimmed.regionMatches(true, 0, "SPLIT", 0, 5)) {
+            String remainder = trimmed.substring(5).replace('+', ',');
+            while (remainder.startsWith(",") || remainder.startsWith("|")) {
+                remainder = remainder.substring(1);
+            }
+            LayerPlan explicit = parse(remainder);
+            return new LayerPlan(true, true, explicit.caveStarts());
+        }
+
         LayerPlan parsed = parse(caveField);
         if (scanMode == ScanMode.SURFACE) {
             if (!parsed.includeAllCaves() && parsed.caveStarts().isEmpty()) {

--- a/libs/platform-api/src/main/java/com/mapsyncer/config/RegionGenerationPlanner.java
+++ b/libs/platform-api/src/main/java/com/mapsyncer/config/RegionGenerationPlanner.java
@@ -15,7 +15,8 @@ import java.util.Set;
  * 根据层计划与运行时维度类型，生成 region 的多 pass 扫描计划。
  *
  * <p>{@code SURFACE} 仅生成地表（有顶盖维度为逻辑顶以上，否则为全列地表）。
- * {@code ALL} 生成维度高度范围内的全部洞穴层。显式 Y 坐标与 {@code ALL} 按层号自动去重。</p>
+ * {@code ALL} 生成维度可玩高度范围内的全部分层洞穴层，{@code FULL} 生成 Xaero 完整洞穴层。
+ * 显式 Y 坐标与 {@code ALL} 按层号自动去重。</p>
  */
 public final class RegionGenerationPlanner {
 
@@ -73,7 +74,8 @@ public final class RegionGenerationPlanner {
     private static void addAllCaveLayers(List<RegionScanPass> passes, Set<Integer> seenLayers,
                                          DimensionTypeInfo info) {
         int minLayer = floorDiv(info.minY(), 16);
-        int maxLayer = floorDiv(info.maxY() - 1, 16);
+        int caveTopY = info.hasUpperZone() ? info.logicalTopY() : info.maxY() - 1;
+        int maxLayer = floorDiv(caveTopY, 16);
         for (int layer = minLayer; layer <= maxLayer; layer++) {
             addCaveLayerPass(passes, seenLayers, layer, info);
         }
@@ -91,8 +93,8 @@ public final class RegionGenerationPlanner {
         if (!seenLayers.add(layer)) {
             return;
         }
-        int depth = caveStart == Integer.MIN_VALUE
-            ? Math.max(30, caveStart - info.minY())
+        int depth = caveStart == LayerPlan.FULL_CAVE_START
+            ? 30
             : CAVE_LAYER_DEPTH;
         passes.add(new RegionScanPass(
             layer,

--- a/libs/platform-api/src/test/java/com/mapsyncer/config/NetherLayerPlanCheck.java
+++ b/libs/platform-api/src/test/java/com/mapsyncer/config/NetherLayerPlanCheck.java
@@ -1,0 +1,42 @@
+package com.mapsyncer.config;
+
+import com.mapsyncer.mca.DimensionTypeInfo;
+import com.mapsyncer.mca.HeightmapStorageCheck;
+import com.mapsyncer.mca.PalettedContainerCheck;
+import com.mapsyncer.mca.convert.scan.RegionScanPass;
+import com.mapsyncer.mca.convert.scan.FullCaveStateCheck;
+
+import java.util.List;
+
+public final class NetherLayerPlanCheck {
+
+    private NetherLayerPlanCheck() {}
+
+    public static void main(String[] args) {
+        LayerPlan legacyDefault = LayerPlan.fromLegacy(ScanMode.CAVE, "SPLIT");
+        assert legacyDefault.equals(LayerPlan.parse("SURFACE,ALL"))
+            : "legacy Nether SPLIT config must retain all playable cave layers";
+
+        List<RegionScanPass> passes = RegionGenerationPlanner.plan(legacyDefault, DimensionTypeInfo.nether());
+
+        assert passes.size() == 9 : "expected surface plus eight playable Nether cave layers";
+        assert passes.get(0).isSurfaceLayer() : "surface pass must be preserved";
+        for (int layer = 0; layer < 8; layer++) {
+            assert passes.get(layer + 1).caveLayer() == layer : "missing Nether cave layer " + layer;
+        }
+
+        LayerPlan fullNether = LayerPlan.parse("SURFACE,ALL,FULL");
+        assert fullNether.toConfigString().equals("SURFACE,ALL,FULL") : "FULL must round-trip";
+
+        passes = RegionGenerationPlanner.plan(fullNether, DimensionTypeInfo.nether());
+        assert passes.size() == 10 : "expected surface, eight layered caves, and full cave mode";
+        RegionScanPass fullPass = passes.get(9);
+        assert fullPass.caveLayer() == Integer.MIN_VALUE : "FULL must use Xaero's full-cave layer";
+        assert fullPass.caveParams().caveStart() == Integer.MIN_VALUE : "FULL must use Xaero's full-cave sentinel";
+        assert fullPass.caveParams().caveDepth() == 30 : "FULL must use Xaero's default cave depth";
+
+        FullCaveStateCheck.run();
+        PalettedContainerCheck.run();
+        HeightmapStorageCheck.run();
+    }
+}

--- a/libs/platform-api/src/test/java/com/mapsyncer/mca/HeightmapStorageCheck.java
+++ b/libs/platform-api/src/test/java/com/mapsyncer/mca/HeightmapStorageCheck.java
@@ -1,0 +1,13 @@
+package com.mapsyncer.mca;
+
+public final class HeightmapStorageCheck {
+
+    private HeightmapStorageCheck() {}
+
+    public static void run() {
+        assert ChunkDataParser.calculateBitsPerHeight(37, 256) == 9
+            : "a 256-high Nether heightmap must use its stored 9-bit width";
+        assert ChunkDataParser.calculateBitsPerHeight(32, 255) == 8
+            : "an eight-bit heightmap must remain eight bits";
+    }
+}

--- a/libs/platform-api/src/test/java/com/mapsyncer/mca/PalettedContainerCheck.java
+++ b/libs/platform-api/src/test/java/com/mapsyncer/mca/PalettedContainerCheck.java
@@ -1,0 +1,14 @@
+package com.mapsyncer.mca;
+
+public final class PalettedContainerCheck {
+
+    private PalettedContainerCheck() {}
+
+    public static void run() {
+        long[] sixBitStorage = new long[410]; // ceil(4096 / floor(64 / 6))
+        assert ChunkSectionParser.calculateBitsPerEntry(17, sixBitStorage) == 6
+            : "stored block-state width must win when a palette has shrunk";
+        assert ChunkSectionParser.calculateBitsPerEntry(16, new long[256]) == 4
+            : "normal four-bit block-state storage must remain unchanged";
+    }
+}

--- a/libs/platform-api/src/test/java/com/mapsyncer/mca/convert/scan/FullCaveStateCheck.java
+++ b/libs/platform-api/src/test/java/com/mapsyncer/mca/convert/scan/FullCaveStateCheck.java
@@ -1,0 +1,45 @@
+package com.mapsyncer.mca.convert.scan;
+
+import com.mapsyncer.mca.BlockPropertyLookup;
+import com.mapsyncer.mca.ChunkSectionParser.BlockState;
+
+import java.util.Map;
+
+public final class FullCaveStateCheck {
+
+    private static final BlockPropertyLookup LOOKUP = new BlockPropertyLookup() {
+        @Override public int getFlags(String name) {
+            return name.equals("minecraft:netherrack") ? FLAG_HAS_VANILLA_COLOR : 0;
+        }
+        @Override public boolean isWater(String name) { return false; }
+        @Override public boolean isTransparent(String name) { return false; }
+        @Override public boolean isInvisible(String name) { return false; }
+        @Override public boolean shouldOverlay(String name) { return false; }
+        @Override public boolean hasVanillaColor(String name) { return true; }
+        @Override public boolean isGrassBlock(String name) { return false; }
+        @Override public boolean isGlowing(String name) { return false; }
+        @Override public boolean isTranslucentFluid(String name) { return false; }
+        @Override public boolean isWaterloggedSurface(String name, Map<String, String> properties) { return false; }
+        @Override public boolean isWaterInheriting(String name) { return false; }
+        @Override public int getLightBlock(String name) { return 15; }
+    };
+
+    private FullCaveStateCheck() {}
+
+    public static void run() {
+        int pos = 0;
+        BlockState netherrack = new BlockState("minecraft:netherrack", Map.of());
+        ColumnScanContext context = new ColumnScanContext(true);
+
+        context.onAir(pos);
+        assert context.shouldEnterGround[pos] : "air above the roof must not disable full-cave ground entry";
+        assert !context.canProcessCaveBlock(pos, true, netherrack, LOOKUP)
+            : "the Nether roof must not become the full-cave map surface";
+        assert !context.underair[pos] && !context.shouldEnterGround[pos]
+            : "full-cave scan must enter the roof before looking for a cave";
+
+        context.onAir(pos);
+        assert context.canProcessCaveBlock(pos, true, netherrack, LOOKUP)
+            : "the first solid below cave air must be rendered";
+    }
+}

--- a/scripts/fastbuild/build-target.ps1
+++ b/scripts/fastbuild/build-target.ps1
@@ -35,13 +35,38 @@ $PropsBak = Join-Path $ProjectRoot "gradle.properties.bak"
 $script:SettingsSwitched = $false
 $script:PropsOverridden = $false
 
+function Test-JdkPath([string]$Path, [int]$Major) {
+    if (-not $Path -or -not (Test-Path (Join-Path $Path "bin\java.exe"))) { return $false }
+    $release = Join-Path $Path "release"
+    $versionPattern = '(?m)^JAVA_VERSION="{0}(?:\.|\")' -f $Major
+    return (Test-Path $release) -and (Get-Content $release -Raw) -match $versionPattern
+}
+
 function Get-JdkPath([int]$Major) {
-    switch ($Major) {
-        17 { return "C:/Program Files/Eclipse Adoptium/jdk-17.0.19.10-hotspot" }
-        21 { return "C:/Program Files/Eclipse Adoptium/jdk-21.0.11.10-hotspot" }
-        25 { return "C:/Program Files/Eclipse Adoptium/jdk-25.0.3.9-hotspot" }
-        default { throw "Unsupported JDK major version: $Major" }
+    $candidates = @(
+        [Environment]::GetEnvironmentVariable("JDK${Major}_HOME"),
+        [Environment]::GetEnvironmentVariable("JAVA${Major}_HOME"),
+        [Environment]::GetEnvironmentVariable("JAVA_HOME_${Major}_X64"),
+        $env:JAVA_HOME
+    )
+
+    $java = Get-Command java.exe -ErrorAction SilentlyContinue
+    if ($java) { $candidates += Split-Path -Parent (Split-Path -Parent $java.Source) }
+
+    foreach ($root in @("$env:ProgramFiles\Java", "$env:ProgramFiles\Eclipse Adoptium")) {
+        if (Test-Path $root) {
+            $candidates += Get-ChildItem $root -Directory -Filter "jdk-$Major*" |
+                Sort-Object Name -Descending | Select-Object -ExpandProperty FullName
+        }
     }
+
+    foreach ($candidate in $candidates | Where-Object { $_ } | Select-Object -Unique) {
+        if (Test-JdkPath $candidate $Major) {
+            return ([System.IO.Path]::GetFullPath($candidate) -replace '\\', '/')
+        }
+    }
+
+    throw "JDK $Major not found. Set JDK${Major}_HOME or JAVA${Major}_HOME."
 }
 
 function Switch-Settings([string]$Profile) {
@@ -96,7 +121,11 @@ function Set-PropsJdk([int]$Major) {
         Copy-Item $PropsFile $PropsBak -Force
     }
     $content = Get-Content $PropsFile -Raw
-    $updated = $content -replace 'org\.gradle\.java\.home=.*', "org.gradle.java.home=$jdkPath"
+    if ($content -match '(?m)^org\.gradle\.java\.home=') {
+        $updated = $content -replace '(?m)^org\.gradle\.java\.home=.*$', "org.gradle.java.home=$jdkPath"
+    } else {
+        $updated = $content.TrimEnd() + "`r`norg.gradle.java.home=$jdkPath`r`n"
+    }
     Set-Content $PropsFile $updated -NoNewline
     $script:PropsOverridden = $true
     $env:JAVA_HOME = $jdkPath -replace '/', '\'


### PR DESCRIPTION
## Summary

Xaero's world map has three cave modes — Off, Layered and Full — but MapSyncer
only ever generated data for the first two, so players who selected Full saw an
empty map. This PR adds a `FULL` layer plan value, and fixes the chunk-decoding
and scan bugs that were corrupting the cave layers we already generated.

While tracing the config path for that work, three settings turned out not to be
wired to anything. Those are fixed here too.

## Layer plans

- New `FULL` value, stored in Xaero's dedicated `caves/-2147483648/` layer with
  the matching cave depth of 30.
- `ALL` now stops at the dimension's logical top, so ceilinged dimensions no
  longer emit unreachable layers above the Nether roof.
- The Nether default becomes `SURFACE,ALL,FULL`, giving all three Xaero cave
  modes backing data.
- Legacy `SPLIT` entries parse into the equivalent surface + all-caves plan.

## Chunk decoding

Two bit-width heuristics were derived from palette size rather than from the
data actually on disk:

- **Block states** — a paletted container can keep a wider bit width than its
  current palette needs. Computing the width from palette size decoded entries
  off-stride, striping the section and turning valid blocks into air.
- **Heightmaps** — a 256-high dimension has to represent offset 256, so it
  stores 9 bits per entry. The old `ceil(log2(256))` gave 8 and misread every
  column.

Both now take the width from the packed long array, matching Minecraft and
Xaero. The full-cave scan also follows Xaero's `underair` / `shouldEnterGround`
state machine, so the Nether roof is traversed instead of being recorded as the
cave surface.

## Config fixes

| Setting | Problem |
|---|---|
| `enableDebugLogging` | Only the 1.20.1 Forge entry point called `applyDebugLogging()`. On the other 11 loader modules the setting did nothing until `/mapsyncer reloadconfig` was run. Now applied on the shared server-start path. |
| `default_scan_mode` / `default_cave_start` | `DimensionRegistry` hardcoded `LayerPlan.surfaceOnly()` when auto-registering a discovered dimension, so neither setting was ever consulted. Now sourced from `getConfigForDimension`. |
| Nether layer plan | `upgradeLegacyNetherDefault` matched on the old default value, which also caught users who had deliberately configured `SURFACE,63` and silently expanded them from 2 layers to 10. Removed. |

Also keeps the startup-detected Minecraft version across `resetRegistration()` —
recreating the `DimensionPathMapping` singleton was reverting 26.x servers to
the 1.21 path layout.

## Build and tooling

- `gradle.properties` no longer hardcodes machine-specific JDK paths; Gradle
  toolchain auto-detect/download handles it, so the repo builds on a clean
  checkout.
- `build-target.ps1` discovers JDKs via `JDK<N>_HOME` / `JAVA_HOME` / standard
  install roots and validates each candidate against its `release` file.
- New assertion-based checks for the layer planner, paletted container,
  heightmap storage and full-cave state machine, wired into `check`.

## Behaviour changes

- **Nether regeneration.** Servers on the old `SURFACE,63` default now generate
  10 layers instead of 2 on next generation. Existing configs with an explicit
  plan are left untouched. Set the Nether back to `SURFACE,63` if you want the
  old footprint.
- **`default_scan_mode` now takes effect.** Servers with it set to `CAVE` will
  register *newly discovered* dimensions as cave layers rather than surface.
  Already-registered dimensions keep their saved plan, so nothing regenerates
  unexpectedly.
- **Existing map data.** The decoding fixes change generator output, so cave
  layers produced before this change may contain the striping/air artefacts
  until regenerated.

## Testing

- `./gradlew :libs:platform-api:check` — all four assertion checks pass.
- `compileJava` green on `mc-1.20.1:fabric`, `mc-1.21.1:fabric`,
  `mc-1.21.1:neoforge`, `mc-1.21.11:neoforge`, `mc-26.1:neoforge`,
  `mc-26.2:neoforge`.
- Not yet verified in-game against a live Xaero client — worth a manual pass on
  a Nether world in all three cave modes before merge.

## Follow-ups

- `CHANGELOG.md` needs a v1.0.4 entry for the `FULL` value and the two
  behaviour changes above.
- Forge and the Loom-isolated Fabric targets build through
  `scripts/fastbuild`, outside the default `settings.gradle`; those were not
  exercised here.